### PR TITLE
Utilise la route plutôt qu’un paramètre pour l’email

### DIFF
--- a/src/api/ressourceProfil.ts
+++ b/src/api/ressourceProfil.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from "express";
+import { Request, Response, Router } from "express";
 import { ConfigurationServeur } from "./configurationServeur";
 import { versProfilAPI } from "./profilAPI";
 
@@ -9,16 +9,15 @@ const ressourceProfil = ({
   const routeur = Router();
 
   routeur.get(
-    "/",
+    "/:email",
     middleware.aseptise("email"),
     async (requete: Request, reponse: Response) => {
-      if (!requete.query.email) {
+      const { email } = requete.params;
+      if (!email) {
         reponse.sendStatus(400);
         return;
       }
-      const profil = await entrepotProfil.parEmail(
-        requete.query.email as string,
-      );
+      const profil = await entrepotProfil.parEmail(email as string);
       if (!profil) {
         reponse.sendStatus(404);
         return;

--- a/tests/api/ressourceProfil.spec.ts
+++ b/tests/api/ressourceProfil.spec.ts
@@ -36,7 +36,7 @@ describe("Sur demande du profil", function () {
 
   it("répond 200", async function () {
     const reponse = await request(serveur)
-      .get("/profil?email=jean@beta.fr")
+      .get("/profil/jean@beta.fr")
       .set("Accept", "application/json");
 
     assert.equal(reponse.status, 200);
@@ -44,7 +44,7 @@ describe("Sur demande du profil", function () {
 
   it("renvoie les données du profil", async () => {
     const reponse = await request(serveur)
-      .get("/profil?email=jean@beta.fr")
+      .get("/profil/jean@beta.fr")
       .set("Accept", "application/json");
 
     assert.deepEqual(reponse.body, {
@@ -63,16 +63,10 @@ describe("Sur demande du profil", function () {
 
   it("répond 404 lorsque le profil est inconnu", async () => {
     const reponse = await request(serveur)
-      .get("/profil?email=inconnu@beta.fr")
+      .get("/profil/inconnu@beta.fr")
       .set("Accept", "application/json");
 
     assert.equal(reponse.status, 404);
-  });
-
-  it("répond 400 lorque l'email n'est pas fourni", async () => {
-    const reponse = await request(serveur).get("/profil");
-
-    assert.equal(reponse.status, 400);
   });
 
   it("aseptise les paramètres", async () => {
@@ -85,7 +79,7 @@ describe("Sur demande du profil", function () {
     };
     await entrepotProfil.ajoute(new Profil(jeanInferieurDujardin));
 
-    const reponse = await request(serveur).get("/profil?email=jean<Dujardin");
+    const reponse = await request(serveur).get("/profil/jean<Dujardin");
 
     assert.equal(reponse.status, 200);
     assert.equal(reponse.body.nom, "Jean Dujardin");


### PR DESCRIPTION
L’idée est d’avoir une ressource de profil dont l’URI sera plutôt `/profil/jean@beta.fr` plutôt que `/profil?email=jean@beta.fr` . Plus concis et _a priori_ plus "RESTful". 