### PR TITLE
Mets à jour le profil lors d'une inscription ultérieure

### DIFF
--- a/src/api/ressourceInscription.ts
+++ b/src/api/ressourceInscription.ts
@@ -50,6 +50,13 @@ const ressourceInscription = ({
         await entrepotProfil.ajoute(profil);
       } else {
         profil.inscrisAuService(serviceClient, adaptateurHorloge);
+        profil.metsAJour({
+          prenom,
+          nom,
+          telephone,
+          domainesSpecialite,
+          organisation,
+        });
         await entrepotProfil.metsAJour(profil);
       }
       reponse.sendStatus(201);

--- a/src/api/ressourceInscription.ts
+++ b/src/api/ressourceInscription.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import { ConfigurationServeur } from "./configurationServeur";
 import { Profil } from "../metier/profil";
+import { ErreurDonneesObligatoiresManquantes } from "../metier/erreurDonneesObligatoiresManquantes";
 
 const ressourceInscription = ({
   entrepotProfil,
@@ -38,14 +39,22 @@ const ressourceInscription = ({
       }
 
       if (!profil) {
-        profil = new Profil({
-          email,
-          nom,
-          prenom,
-          organisation,
-          domainesSpecialite,
-          telephone,
-        });
+        try {
+          profil = new Profil({
+            email,
+            nom,
+            prenom,
+            organisation,
+            domainesSpecialite,
+            telephone,
+          });
+        } catch (e) {
+          if (e instanceof ErreurDonneesObligatoiresManquantes) {
+            reponse.status(400).send({ erreur: e.message });
+            return;
+          }
+          throw e;
+        }
         profil.inscrisAuService(serviceClient, adaptateurHorloge);
         await entrepotProfil.ajoute(profil);
       } else {

--- a/src/metier/erreurDonneesObligatoiresManquantes.ts
+++ b/src/metier/erreurDonneesObligatoiresManquantes.ts
@@ -1,0 +1,8 @@
+export class ErreurDonneesObligatoiresManquantes implements Error {
+    message: string;
+    name: string = "ErreurDonneesObligatoiresManquantes";
+
+    constructor(champ: string) {
+        this.message = `Le champ [${champ}] est obligatoire`;
+    }
+}

--- a/src/metier/organisation.ts
+++ b/src/metier/organisation.ts
@@ -1,5 +1,16 @@
+import { ErreurDonneesObligatoiresManquantes } from "./erreurDonneesObligatoiresManquantes";
+
 export interface Organisation {
   nom: string;
   siret: string;
   departement: string;
 }
+
+export const valideOrganisation = (organisation: Organisation) => {
+  if (!organisation.nom)
+    throw new ErreurDonneesObligatoiresManquantes("organisation.nom");
+  if (!organisation.departement)
+    throw new ErreurDonneesObligatoiresManquantes("organisation.departement");
+  if (!organisation.siret)
+    throw new ErreurDonneesObligatoiresManquantes("organisation.siret");
+};

--- a/src/metier/profil.ts
+++ b/src/metier/profil.ts
@@ -1,8 +1,9 @@
 import { AdaptateurHorloge } from "./adaptateurHorloge";
 import { Inscription } from "./inscription";
-import { Organisation } from "./organisation";
+import { Organisation, valideOrganisation } from "./organisation";
+import { ErreurDonneesObligatoiresManquantes } from "./erreurDonneesObligatoiresManquantes";
 
-type DonneesCreationProfil = {
+export type DonneesCreationProfil = {
   email: string;
   nom: string;
   prenom: string;
@@ -11,7 +12,7 @@ type DonneesCreationProfil = {
   telephone?: string;
 };
 
-type DonneesMiseAJourProfil = Omit<Partial<DonneesCreationProfil>, 'email'>;
+type DonneesMiseAJourProfil = Omit<Partial<DonneesCreationProfil>, "email">;
 
 export class Profil {
   email: string;
@@ -22,20 +23,33 @@ export class Profil {
   telephone?: string;
   inscriptions: Inscription[] = [];
 
-  constructor({
-    email,
-    nom,
-    prenom,
-    organisation,
-    domainesSpecialite,
-    telephone,
-  }: DonneesCreationProfil) {
+  constructor(donneesCreationProfil: DonneesCreationProfil) {
+    this.valide(donneesCreationProfil);
+    const { email, nom, prenom, organisation, domainesSpecialite, telephone } =
+      donneesCreationProfil;
     this.email = email;
     this.nom = nom;
     this.prenom = prenom;
     this.organisation = organisation;
     this.domainesSpecialite = domainesSpecialite;
     this.telephone = telephone;
+  }
+
+  private valide({
+    email,
+    nom,
+    prenom,
+    organisation,
+    domainesSpecialite,
+  }: DonneesCreationProfil) {
+    if (!email) throw new ErreurDonneesObligatoiresManquantes("email");
+    if (!prenom) throw new ErreurDonneesObligatoiresManquantes("prenom");
+    if (!nom) throw new ErreurDonneesObligatoiresManquantes("nom");
+    if (!domainesSpecialite || domainesSpecialite.length === 0)
+      throw new ErreurDonneesObligatoiresManquantes("domainesSpecialite");
+    if (!organisation)
+      throw new ErreurDonneesObligatoiresManquantes("organisation");
+    valideOrganisation(organisation);
   }
 
   inscrisAuService(service: string, adaptateurHorloge: AdaptateurHorloge) {

--- a/src/metier/profil.ts
+++ b/src/metier/profil.ts
@@ -2,7 +2,7 @@ import { AdaptateurHorloge } from "./adaptateurHorloge";
 import { Inscription } from "./inscription";
 import { Organisation } from "./organisation";
 
-type DonneesProfil = {
+type DonneesCreationProfil = {
   email: string;
   nom: string;
   prenom: string;
@@ -10,6 +10,8 @@ type DonneesProfil = {
   domainesSpecialite: string[];
   telephone?: string;
 };
+
+type DonneesMiseAJourProfil = Omit<Partial<DonneesCreationProfil>, 'email'>;
 
 export class Profil {
   email: string;
@@ -19,6 +21,7 @@ export class Profil {
   domainesSpecialite: string[];
   telephone?: string;
   inscriptions: Inscription[] = [];
+
   constructor({
     email,
     nom,
@@ -26,7 +29,7 @@ export class Profil {
     organisation,
     domainesSpecialite,
     telephone,
-  }: DonneesProfil) {
+  }: DonneesCreationProfil) {
     this.email = email;
     this.nom = nom;
     this.prenom = prenom;
@@ -55,5 +58,19 @@ export class Profil {
 
   nombreInscriptions() {
     return this.inscriptions.length;
+  }
+
+  metsAJour({
+    prenom,
+    nom,
+    telephone,
+    organisation,
+    domainesSpecialite,
+  }: DonneesMiseAJourProfil) {
+    if (prenom) this.prenom = prenom;
+    if (nom) this.nom = nom;
+    if (telephone) this.telephone = telephone;
+    if (organisation) this.organisation = organisation;
+    if (domainesSpecialite) this.domainesSpecialite = domainesSpecialite;
   }
 }

--- a/tests/api/ressourceProfil.spec.ts
+++ b/tests/api/ressourceProfil.spec.ts
@@ -73,9 +73,9 @@ describe("Sur demande du profil", function () {
     const jeanInferieurDujardin = {
       email: "jean&lt;Dujardin",
       nom: "Jean Dujardin",
-      prenom: "",
+      prenom: " d",
       organisation: { nom: "DINUM", siret: "12345678", departement: "33" },
-      domainesSpecialite: [],
+      domainesSpecialite: ["RSSI"],
     };
     await entrepotProfil.ajoute(new Profil(jeanInferieurDujardin));
 

--- a/tests/metier/profil.spec.ts
+++ b/tests/metier/profil.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it } from "node:test";
+
+import assert from "assert";
+import { DonneesCreationProfil, Profil } from "../../src/metier/profil";
+import { Organisation } from "../../src/metier/organisation";
+
+describe("Sur construction d'un profil", () => {
+  const organisation: Organisation = {
+    nom: "DINUM",
+    departement: "33",
+    siret: "1234",
+  };
+  const donneesCreationProfil: Partial<DonneesCreationProfil> = {
+    prenom: "Jean",
+    nom: "Dujardin",
+    email: "jeand@beta.fr",
+    organisation,
+    domainesSpecialite: ["RSSI"],
+  };
+
+  it("n'accepte pas un email vide", () => {
+    assert.throws(
+      () =>
+        new Profil({
+          ...donneesCreationProfil,
+          email: "",
+        } as DonneesCreationProfil),
+      {
+        name: "ErreurDonneesObligatoiresManquantes",
+        message: "Le champ [email] est obligatoire",
+      },
+    );
+  });
+
+  it("n'accepte pas un prenom vide", () => {
+    assert.throws(
+      () =>
+        new Profil({
+          ...donneesCreationProfil,
+          prenom: "",
+        } as DonneesCreationProfil),
+      {
+        name: "ErreurDonneesObligatoiresManquantes",
+        message: "Le champ [prenom] est obligatoire",
+      },
+    );
+  });
+
+  it("n'accepte pas un nom vide", () => {
+    assert.throws(
+      () =>
+        new Profil({
+          ...donneesCreationProfil,
+          nom: "",
+        } as DonneesCreationProfil),
+      {
+        name: "ErreurDonneesObligatoiresManquantes",
+        message: "Le champ [nom] est obligatoire",
+      },
+    );
+  });
+
+  it("n'accepte pas une organisation vide", () => {
+    let donnees = { ...donneesCreationProfil };
+    delete donnees.organisation;
+    assert.throws(() => new Profil(donnees as DonneesCreationProfil), {
+      name: "ErreurDonneesObligatoiresManquantes",
+      message: "Le champ [organisation] est obligatoire",
+    });
+  });
+
+  it("n'accepte pas un nom d'organisation vide", () => {
+    const donneesOrganisation = { ...organisation, nom: "" };
+    let donnees = {
+      ...donneesCreationProfil,
+      organisation: donneesOrganisation,
+    };
+    assert.throws(() => new Profil(donnees as DonneesCreationProfil), {
+      name: "ErreurDonneesObligatoiresManquantes",
+      message: "Le champ [organisation.nom] est obligatoire",
+    });
+  });
+
+  it("n'accepte pas un département d'organisation vide", () => {
+    const donneesOrganisation = { ...organisation, departement: "" };
+    let donnees = {
+      ...donneesCreationProfil,
+      organisation: donneesOrganisation,
+    };
+    assert.throws(() => new Profil(donnees as DonneesCreationProfil), {
+      name: "ErreurDonneesObligatoiresManquantes",
+      message: "Le champ [organisation.departement] est obligatoire",
+    });
+  });
+
+  it("n'accepte pas un siret d'organisation vide", () => {
+    const donneesOrganisation = { ...organisation, siret: "" };
+    let donnees = {
+      ...donneesCreationProfil,
+      organisation: donneesOrganisation,
+    };
+    assert.throws(() => new Profil(donnees as DonneesCreationProfil), {
+      name: "ErreurDonneesObligatoiresManquantes",
+      message: "Le champ [organisation.siret] est obligatoire",
+    });
+  });
+
+  it("n'accepte pas un champ domaine de spécialité vide", () => {
+    let donnees = { ...donneesCreationProfil };
+    delete donnees.domainesSpecialite;
+    assert.throws(() => new Profil(donnees as DonneesCreationProfil), {
+      name: "ErreurDonneesObligatoiresManquantes",
+      message: "Le champ [domainesSpecialite] est obligatoire",
+    });
+  });
+
+  it("n'accepte pas une liste vide de domaines de spécialité", () => {
+    assert.throws(
+      () =>
+        new Profil({
+          ...donneesCreationProfil,
+          domainesSpecialite: [],
+        } as DonneesCreationProfil),
+      {
+        name: "ErreurDonneesObligatoiresManquantes",
+        message: "Le champ [domainesSpecialite] est obligatoire",
+      },
+    );
+  });
+});


### PR DESCRIPTION
Lorsqu'un utilisateur déjà connu s'inscrit à un nouveau service, il peut envoyer des nouvelles données de profil qui n'étaient pas encore connues. On les sauvegarde.

Également, valide les données passées à la création du profil.