### PR TITLE
Securise la ressource profil

### DIFF
--- a/src/api/ressourceProfil.ts
+++ b/src/api/ressourceProfil.ts
@@ -38,6 +38,7 @@ const ressourceProfil = ({
       "domainesSpecialite.*",
       "telephone",
     ),
+    middleware.decodeJeton(),
     async (requete, reponse) => {
       const { email } = requete.params;
       const { nom, prenom, telephone, organisation, domainesSpecialite } =

--- a/src/api/ressourceProfil.ts
+++ b/src/api/ressourceProfil.ts
@@ -11,6 +11,7 @@ const ressourceProfil = ({
   routeur.get(
     "/:email",
     middleware.aseptise("email"),
+    middleware.decodeJeton(),
     async (requete: Request, reponse: Response) => {
       const { email } = requete.params;
       if (!email) {


### PR DESCRIPTION
Afin que seuls les services qui ont passés un jeton valide dans l’entête d’autorisation puisse obtenir et mettre à jour un profil.