### PR TITLE
Ajuste la limite de requêtes par seconde

### DIFF
--- a/src/api/mpa.ts
+++ b/src/api/mpa.ts
@@ -7,8 +7,8 @@ import rateLimit from "express-rate-limit";
 const creeServeur = (configurationServeur: ConfigurationServeur) => {
   const app = express();
 
-  const centParMinute = rateLimit({ windowMs: 60 * 1000, limit: 100 });
-  app.use(centParMinute);
+  const vingtParSeconde = rateLimit({ windowMs: 1000, limit: 20 });
+  app.use(vingtParSeconde);
   app.use(express.json());
 
   app.use("/profil", ressourceProfil(configurationServeur));


### PR DESCRIPTION
...en utilisant une valeur de 20 requête par seconde, ce qui doit être, empiriquement, gérable par MPA