### PR TITLE
[CORRECTION] Assure une connexion unique vers la BDD

### DIFF
--- a/src/persistance/entrepotProfil.postgres.ts
+++ b/src/persistance/entrepotProfil.postgres.ts
@@ -1,20 +1,9 @@
 import { Profil } from "../metier/profil";
-import knex, { Knex } from "knex";
 import { EntrepotProfil } from "../metier/entrepotProfil";
-import { knexConfig } from "./knexfile";
+import { db } from "./knexfile";
 import { Inscription } from "../metier/inscription";
 import { AdaptateurHachage } from "./adaptateurHachage";
-import { AdaptateurChiffrement, ObjetChiffre } from "./adaptateurChiffrement";
-import { ProfilDb } from "./profilDb";
-
-type NodeEnv = "development" | "production";
-
-const connexion = () => {
-  const nodeEnv = process.env.NODE_ENV;
-  if (!nodeEnv)
-    throw new Error("Configuration invalide : NODE_ENV non renseigné.");
-  return knex(knexConfig[nodeEnv as NodeEnv]);
-};
+import { AdaptateurChiffrement } from "./adaptateurChiffrement";
 
 export const entrepotProfilPostgres = ({
   adaptateurChiffrement,
@@ -27,11 +16,7 @@ export const entrepotProfilPostgres = ({
     return adaptateurHachage.hacheSha256(email);
   };
 
-  async function metsAJourInscriptions(
-    db: Knex<any, unknown[]>,
-    profil: Profil,
-    emailHash: string,
-  ) {
+  async function metsAJourInscriptions(profil: Profil, emailHash: string) {
     const donnees = await adaptateurChiffrement.chiffre({
       email: profil.email,
     });
@@ -48,7 +33,6 @@ export const entrepotProfilPostgres = ({
 
   return {
     async metsAJour(profil: Profil): Promise<void> {
-      const db = connexion();
       const {
         email,
         prenom,
@@ -70,11 +54,10 @@ export const entrepotProfilPostgres = ({
         email_hash: emailHash,
         donnees,
       });
-      await metsAJourInscriptions(db, profil, emailHash);
+      await metsAJourInscriptions(profil, emailHash);
     },
 
     async ajoute(profil: Profil): Promise<void> {
-      const db = connexion();
       const {
         email,
         prenom,
@@ -96,11 +79,10 @@ export const entrepotProfilPostgres = ({
         email_hash: emailHash,
         donnees,
       });
-      await metsAJourInscriptions(db, profil, emailHash);
+      await metsAJourInscriptions(profil, emailHash);
     },
 
     async parEmail(email: string): Promise<Profil | undefined> {
-      const db = connexion();
       const emailHash = hashEmail(email);
       const donneesProfilChiffrees = await db("profils")
         .where({ email_hash: emailHash })

--- a/src/persistance/entrepotRevocationJeton.postgres.ts
+++ b/src/persistance/entrepotRevocationJeton.postgres.ts
@@ -1,27 +1,15 @@
-import knex from "knex";
-import { knexConfig } from "./knexfile";
+import { db } from "./knexfile";
 import { EntrepotRevocationJeton } from "../api/entrepotRevocationJeton";
 import { RevocationJeton } from "../api/revocationJeton";
 
-type NodeEnv = "development" | "production";
-
-const connexion = () => {
-  const nodeEnv = process.env.NODE_ENV;
-  if (!nodeEnv)
-    throw new Error("Configuration invalide : NODE_ENV non renseigné.");
-  return knex(knexConfig[nodeEnv as NodeEnv]);
-};
-
 export const entrepotRevocationJetonPostgres: EntrepotRevocationJeton = {
   async ajoute(revocationJeton: RevocationJeton) {
-    let db = connexion();
     await db("revocations_jeton").insert({
       service: revocationJeton.service,
       date_fin_revocation: revocationJeton.dateFinRevocation,
     });
   },
   async pourService(service: string): Promise<RevocationJeton | undefined> {
-    let db = connexion();
     let donnees = await db("revocations_jeton")
       .where({ service })
       .orderBy("date_fin_revocation", "desc")

--- a/src/persistance/knexfile.ts
+++ b/src/persistance/knexfile.ts
@@ -1,3 +1,5 @@
+import knex from "knex";
+
 export const knexConfig = {
   development: {
     client: "pg",
@@ -13,3 +15,10 @@ export const knexConfig = {
     migrations: { tableName: "knex_migrations" },
   },
 };
+
+type NodeEnv = "development" | "production";
+const nodeEnv = process.env.NODE_ENV;
+if (!nodeEnv)
+  throw new Error("Configuration invalide : NODE_ENV non renseigné.");
+
+export const db = knex(knexConfig[nodeEnv as NodeEnv]);


### PR DESCRIPTION
... en utilisant un objet `Knex` unique.
Ce problème a été identifié lors d'une tentative de migraiton des profils de MSS :
- On se rend compte qu'une nouvelle connexion `knex` est instancié pour chaque méthode des entrepôts
- Les entrepôts devraient partage un seul objet Knex, qui est responsable de gérer son pool de connexion, via le `knexfile`.