### PR TITLE
Corrige les mails qui contiennent des majuscules

### DIFF
--- a/src/admin/consoleMailsMajuscules.ts
+++ b/src/admin/consoleMailsMajuscules.ts
@@ -1,0 +1,126 @@
+import {
+  AdaptateurChiffrement,
+  fabriqueAdaptateurChiffrement,
+} from "../persistance/adaptateurChiffrement";
+import { adaptateurEnvironnement } from "../adaptateurEnvironnement";
+import { db } from "../persistance/knexfile";
+import { fabriqueAdaptateurHachage } from "../persistance/adaptateurHachage";
+
+type ProfilBrut = { donnees: any; mailHash: string };
+
+async function dechiffreProfilsBruts(
+  profilBruts: any[],
+  adaptateurChiffrement: AdaptateurChiffrement,
+) {
+  const profils: ProfilBrut[] = [];
+  for (const profilBrut of profilBruts) {
+    profils.push({
+      donnees: await adaptateurChiffrement.dechiffre(profilBrut.donnees),
+      mailHash: profilBrut.email_hash,
+    });
+  }
+  return profils;
+}
+
+export const ConsoleMailsMajuscules = {
+  async dedoublonne() {
+    let adaptateurChiffrement = fabriqueAdaptateurChiffrement({
+      adaptateurEnvironnement,
+    });
+
+    const profilBruts = await db("profils").select();
+
+    function trouveDoublons() {
+      let nombreParEmail: Record<string, number> = {};
+      const doublons: ProfilBrut[] = [];
+      profils.forEach(function (profil) {
+        const emailEnMinuscule = profil.donnees.email.toLowerCase();
+        if (nombreParEmail[emailEnMinuscule] > 0) {
+          doublons.push(profil);
+        }
+        nombreParEmail[emailEnMinuscule] =
+          (nombreParEmail[emailEnMinuscule] || 0) + 1;
+      });
+      return doublons;
+    }
+
+    const profils = await dechiffreProfilsBruts(
+      profilBruts,
+      adaptateurChiffrement,
+    );
+    const doublons = trouveDoublons();
+    console.log("Suppression de doublons : ", doublons.length);
+
+    for (const doublon of doublons) {
+      await db("inscriptions").where({ email_hash: doublon.mailHash }).del();
+      await db("profils").where({ email_hash: doublon.mailHash }).del();
+    }
+  },
+  async convertisEnMinuscule() {
+    const adaptateurChiffrement = fabriqueAdaptateurChiffrement({
+      adaptateurEnvironnement,
+    });
+    const adaptateurHachage = fabriqueAdaptateurHachage({
+      adaptateurEnvironnement,
+    });
+
+    const inscriptionsChiffrees = await db("inscriptions").select();
+    const inscriptions = [];
+    for (const inscriptionChiffree of inscriptionsChiffrees) {
+      inscriptions.push({
+        donnees: await adaptateurChiffrement.dechiffre<{ email: string }>(
+          inscriptionChiffree.donnees,
+        ),
+        mailHash: inscriptionChiffree.email_hash,
+      });
+    }
+    for (const inscription of inscriptions) {
+      if (
+        inscription.donnees.email.toLowerCase() !== inscription.donnees.email
+      ) {
+        const nouveauHash = adaptateurHachage.hacheSha256(
+          inscription.donnees.email.toLowerCase(),
+        );
+        let donnees = await adaptateurChiffrement.chiffre({
+          email: inscription.donnees.email.toLowerCase(),
+        });
+        console.log(
+          "Mise en minuscule de l'email de l'inscription. Nouveau hash = ",
+          nouveauHash,
+        );
+        await db("inscriptions")
+          .where({ email_hash: inscription.mailHash })
+          .update({
+            email_hash: nouveauHash,
+            donnees,
+          });
+      }
+    }
+
+    const profilsChiffrees = await db("profils").select();
+    const profils = await dechiffreProfilsBruts(
+      profilsChiffrees,
+      adaptateurChiffrement,
+    );
+
+    for (const profil of profils) {
+      if (profil.donnees.email.toLowerCase() !== profil.donnees.email) {
+        const nouveauHash = adaptateurHachage.hacheSha256(
+          profil.donnees.email.toLowerCase(),
+        );
+        let donnees = await adaptateurChiffrement.chiffre({
+          ...profil.donnees,
+          email: profil.donnees.email.toLowerCase(),
+        });
+        console.log(
+          "Mise en minuscule de l'email du profil. Nouveau hash = ",
+          nouveauHash,
+        );
+        await db("profils").where({ email_hash: profil.mailHash }).update({
+          email_hash: nouveauHash,
+          donnees,
+        });
+      }
+    }
+  },
+};

--- a/src/api/ressourceInscriptions.ts
+++ b/src/api/ressourceInscriptions.ts
@@ -76,7 +76,7 @@ const ressourceInscriptions = ({
       }
       const promesses = donnees.map((demandeInscription) =>
         entrepotProfil
-          .parEmail(demandeInscription.donneesProfil.email)
+          .parEmail(demandeInscription.donneesProfil.email.toLowerCase())
           .then((profil) => {
             const dateInscription = new Date(
               demandeInscription.dateInscription,

--- a/src/api/ressourceProfil.ts
+++ b/src/api/ressourceProfil.ts
@@ -38,7 +38,7 @@ const ressourceProfil = ({
         reponse.sendStatus(400);
         return;
       }
-      const profil = await entrepotProfil.parEmail(email as string);
+      const profil = await entrepotProfil.parEmail((email as string).toLowerCase());
       if (!profil) {
         // #swagger.responses[404] = { description: 'L\'utilisateur est introuvable' }
         reponse.sendStatus(404);

--- a/src/api/ressourceProfil.ts
+++ b/src/api/ressourceProfil.ts
@@ -88,7 +88,7 @@ const ressourceProfil = ({
       const { email } = requete.params;
       const { nom, prenom, telephone, organisation, domainesSpecialite } =
         requete.body;
-      let profil = await entrepotProfil.parEmail(email);
+      let profil = await entrepotProfil.parEmail(email.toLowerCase());
       const serviceClient = (requete as Request & { service: string }).service;
 
       if (!profil) {

--- a/src/metier/profil.ts
+++ b/src/metier/profil.ts
@@ -27,7 +27,7 @@ export class Profil {
     this.valide(donneesCreationProfil);
     const { email, nom, prenom, organisation, domainesSpecialite, telephone } =
       donneesCreationProfil;
-    this.email = email;
+    this.email = email.toLowerCase();
     this.nom = nom;
     this.prenom = prenom;
     this.organisation = organisation;

--- a/tests/api/ressourceInscriptions.spec.ts
+++ b/tests/api/ressourceInscriptions.spec.ts
@@ -292,5 +292,24 @@ describe("La ressource inscriptions", () => {
         );
       });
     });
+
+    describe("concernant la casse des emails", () => {
+      it("utilise l'email en minuscule pour vérifier son existence", async () => {
+        await serviceInscription.nouveauProfil(
+          donneesProfilJeanDujardin,
+          "mac",
+        );
+
+        await postDepuisMss.send([
+          {
+            dateInscription: new Date("2020-10-25"),
+            donneesProfil: { ...donneesProfilJeanDujardin, email: "JEAN@beta.fr" },
+          },
+        ]);
+
+        const jean = await entrepotProfil.parEmail("jean@beta.fr");
+        assert.equal(jean?.estInscritA("mss"), true);
+      });
+    });
   });
 });

--- a/tests/api/ressourceProfil.spec.ts
+++ b/tests/api/ressourceProfil.spec.ts
@@ -85,7 +85,7 @@ describe("La ressource profil", () => {
 
     it("aseptise les paramètres", async () => {
       const jeanInferieurDujardin = {
-        email: "jean&lt;Dujardin",
+        email: "jean&lt;dujardin",
         nom: "Jean Dujardin",
         prenom: " d",
         organisation: { nom: "DINUM", siret: "12345678", departement: "33" },
@@ -93,7 +93,7 @@ describe("La ressource profil", () => {
       };
       await entrepotProfil.ajoute(new Profil(jeanInferieurDujardin));
 
-      const reponse = await requeteGETAuthentifiee("/profil/jean<Dujardin");
+      const reponse = await requeteGETAuthentifiee("/profil/jean<dujardin");
 
       assert.equal(reponse.status, 200);
       assert.equal(reponse.body.nom, "Jean Dujardin");
@@ -276,6 +276,23 @@ describe("La ressource profil", () => {
         .set("Accept", "application/json");
 
       assert.equal(reponse.status, 401);
+    });
+
+    describe("concernant la casse de l'email", () => {
+      it("mets à jour un profil existant, même lorsque les casses diffèrent", async () => {
+        await requetePUTAuthentifiee(
+          "/profil/JEAN@beta.fr",
+        ).send({
+          nom: "Dujardin",
+          prenom: "JEAN",
+          organisation: { nom: "DINUM", siret: "12345678", departement: "33" },
+          domainesSpecialite: ["RSSI"],
+          telephone: "0607080910",
+        });
+
+        const jeanAJour = await entrepotProfil.parEmail("jean@beta.fr");
+        assert.equal(jeanAJour?.prenom, "JEAN");
+      });
     });
   });
 });

--- a/tests/api/ressourceProfil.spec.ts
+++ b/tests/api/ressourceProfil.spec.ts
@@ -106,6 +106,12 @@ describe("La ressource profil", () => {
 
       assert.equal(reponse.status, 401);
     });
+
+    it("est insensible à la casse de l'email", async () => {
+      const reponse = await requeteGETAuthentifiee("/profil/JEAN@beta.fr");
+
+      assert.equal(reponse.body.email, "jean@beta.fr");
+    });
   });
 
   describe("Sur demande de mise à jour du profil", () => {

--- a/tests/metier/profil.spec.ts
+++ b/tests/metier/profil.spec.ts
@@ -127,4 +127,13 @@ describe("Sur construction d'un profil", () => {
       },
     );
   });
+
+  it("transforme son email en minuscule lors de la création", () => {
+    const profil = new Profil({
+      ...donneesCreationProfil,
+      email: "JEAN@beta.fr",
+    } as DonneesCreationProfil);
+
+    assert.equal(profil.email, "jean@beta.fr");
+  });
 });


### PR DESCRIPTION
Pour cela, on s’assure que tous les emails sont mis en minuscules avant d’être écrits en base de données. Si des majuscules sont passées pour récupérer un profil, une mise en minuscule est faite avant. 

Enfin, nous rattrapons tous les profils et les inscriptions qui ont des majuscules en base de données. Les doublons éventuels (deux à ce jour) sont supprimés. 