### PR TITLE
[CORRECTION] Utilise pnpm dans le Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ ARG NODE_VERSION=latest
 
 FROM docker.io/node:$NODE_VERSION
 
+RUN apt-get update -y
+RUN apt-get install -y jq
+
 WORKDIR /usr/src/app
-COPY package.json package-lock.json /usr/src/app/
+COPY package.json pnpm-lock.yaml /usr/src/app/
 RUN npm install -g "$(jq -r '.packageManager' package.json)"
 RUN pnpm install
 


### PR DESCRIPTION
Avant ce commit, il restait des bribes de `npm` en tant que package manager.