### PR TITLE
[ADMIN] Ajoute la console de migration des `decode()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@lab-anssi/lib": "2.1.3",
     "dotenv": "^16.6.1",
     "express": "^4.22.1",
+    "html-entities": "2.6.0",
     "jsonwebtoken": "^9.0.3",
     "knex": "^3.1.0",
     "pg": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       express:
         specifier: ^4.22.1
         version: 4.22.1
+      html-entities:
+        specifier: 2.6.0
+        version: 2.6.0
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3

--- a/src/admin/consoleMigrationDecodeHtml.ts
+++ b/src/admin/consoleMigrationDecodeHtml.ts
@@ -1,0 +1,58 @@
+import {
+  AdaptateurChiffrement,
+  fabriqueAdaptateurChiffrement,
+} from "../persistance/adaptateurChiffrement";
+import { adaptateurEnvironnement } from "../adaptateurEnvironnement";
+import { db } from "../persistance/knexfile";
+import { decode } from "html-entities";
+import { fabriqueAdaptateurHachage } from "../persistance/adaptateurHachage";
+
+type ProfilBrut = { donnees: any; mailHash: string };
+
+async function dechiffreProfilsBruts(
+  profilBruts: any[],
+  adaptateurChiffrement: AdaptateurChiffrement,
+) {
+  const profils: ProfilBrut[] = [];
+  for (const profilBrut of profilBruts) {
+    profils.push({
+      donnees: await adaptateurChiffrement.dechiffre(profilBrut.donnees),
+      mailHash: profilBrut.email_hash,
+    });
+  }
+  return profils;
+}
+
+const enleveEntitesHTML = (dechiffrees: any) =>
+  JSON.parse(
+    JSON.stringify(dechiffrees, (_cle, valeur) =>
+      typeof valeur === "string" ? decode(valeur) : valeur,
+    ),
+  );
+
+export const ConsoleMigrationDecodeHtml = {
+  async decodeTout() {
+    const chiffrement = fabriqueAdaptateurChiffrement({
+      adaptateurEnvironnement,
+    });
+    const hache = fabriqueAdaptateurHachage({ adaptateurEnvironnement });
+
+    await db.transaction(async (trx) => {
+      const profilBruts = await trx("profils").select();
+      const profilsClairs = await dechiffreProfilsBruts(
+        profilBruts,
+        chiffrement,
+      );
+
+      for (let profil of profilsClairs) {
+        const nouvellesDonnees = await enleveEntitesHTML(profil.donnees)
+        const nouveauHash = hache.hacheSha256(nouvellesDonnees.email);
+        const donneesChiffrees = await chiffrement.chiffre(nouvellesDonnees);
+        console.table({ nouveauHash, ancienHash: profil.mailHash });
+        await trx("profils")
+          .where({ email_hash: profil.mailHash })
+          .update({ donnees: donneesChiffrees, email_hash: nouveauHash });
+      }
+    });
+  },
+};


### PR DESCRIPTION
On veut pouvoir mettre à jour l'intégralité de la table `profils` pour la débarrasser des données encodées.